### PR TITLE
Fix chunk assume_init

### DIFF
--- a/src/chunked_vec.rs
+++ b/src/chunked_vec.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 /// A vector-like container that stores elements in fixed-size chunks, providing efficient
 /// memory allocation and element access.
 ///
@@ -46,5 +48,5 @@ pub struct ChunkedVecSized<T, const N: usize>(std::marker::PhantomData<T>);
 ///
 /// Each chunk is a boxed array of exactly `N` elements, where `N` is the chunk size.
 /// Using `Box` helps reduce stack pressure when chunk sizes are large.
-pub type Chunk<T, const N: usize = { crate::DEFAULT_CHUNK_SIZE }> = Box<[T; N]>;
+pub type Chunk<T, const N: usize = { crate::DEFAULT_CHUNK_SIZE }> = Box<[MaybeUninit<T>; N]>;
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -18,7 +18,7 @@ impl<T, const N: usize> ChunkedVec<T, N> {
     pub unsafe fn get_unchecked(&self, index: usize) -> &T {
         let chunk_idx = index / N;
         let offset = index % N;
-        self.data.get_unchecked(chunk_idx).get_unchecked(offset)
+        self.data.get_unchecked(chunk_idx)[offset].assume_init_ref()
     }
 
     /// Returns a mutable reference to an element without performing bounds checking.
@@ -32,7 +32,7 @@ impl<T, const N: usize> ChunkedVec<T, N> {
     pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> &mut T {
         let chunk_idx = index / N;
         let offset = index % N;
-        &mut (*self.data.get_unchecked_mut(chunk_idx))[offset]
+        self.data.get_unchecked_mut(chunk_idx)[offset].assume_init_mut()
     }
 
     /// Returns a reference to an element at the given index.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,12 +1,12 @@
+use std::array::from_fn;
+use std::mem::MaybeUninit;
 use crate::{Chunk, ChunkedVec};
 
 impl<T, const N: usize> ChunkedVec<T, N> {
     pub(crate) fn create_new_chunk(value: T) -> Chunk<T, N> {
-        let mut chunk = Box::new_uninit_slice(N);
+        let arr: [MaybeUninit<T>; N] = from_fn(|_| MaybeUninit::uninit());
+        let mut chunk: Chunk<T, N> = Box::new(arr);
         chunk[0].write(value);
-        unsafe {
-            let ptr = Box::into_raw(chunk) as *mut [T; N];
-            Box::from_raw(ptr)
-        }
+        chunk
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,3 +1,4 @@
+use std::mem::MaybeUninit;
 use crate::ChunkedVec;
 
 /// Implementation of basic operations for ChunkedVec.
@@ -29,7 +30,7 @@ impl<T, const N: usize> ChunkedVec<T, N> {
             let chunk = Self::create_new_chunk(value);
             self.data.push(chunk);
         } else {
-            self.data[chunk_idx][offset] = value;
+            self.data[chunk_idx][offset] = MaybeUninit::new(value);
         }
         self.len += 1;
     }


### PR DESCRIPTION
⚠️ Important Note
assume_init() must only be called when all elements are fully initialized.

If you initialize just one element and then call assume_init(), you can trigger undefined behavior.

The bug fixed here was exactly this scenario. Previously, Box<[T; N]> incorrectly assumed that all T elements were initialized when using:

```rust
let ptr = Box::into_raw(chunk) as *mut [T; N];
Box::from_raw(ptr)
```
To fix this, I removed that usage and replaced it with [MaybeUninit<T>; N].