### PR TITLE
feat: add optional serde support via `serde` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,15 @@ name = "chunked_vec"
 version = "0.3.4"
 dependencies = [
  "likely_stable",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "likely_stable"
@@ -16,6 +24,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61f7017d8abea1fc23ff7f01a8147b2656dea3aeb24d519aab6e2177eaf671c"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -32,3 +64,68 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,13 @@ categories = ["data-structures"]
 
 [dependencies]
 likely_stable = "0.1.3"
+serde = { version = "1.0.228", default-features = false, features = ["std"], optional = true }
+
+[dev-dependencies]
+serde_json = { version = "1.0.105", default-features = false, features = ["alloc", "std"] }
+
+[features]
+serde = ["dep:serde"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,12 @@
 //! - Standard vector-like interface
 //! - Index-based access with bounds checking
 //!
+//! # Feature flags
+//! - `serde` — enables [`serde::Serialize`](https://docs.rs/serde/latest/serde/trait.Serialize.html)
+//!   and [`serde::Deserialize`](https://docs.rs/serde/latest/serde/trait.Deserialize.html) for
+//!   `ChunkedVec<T, N>`, serialized as a plain sequence interoperable with `Vec<T>`.
+//!   Disabled by default.
+//!
 //! # Example
 //! ```
 //! use chunked_vec::ChunkedVec;
@@ -25,6 +31,8 @@ mod index;
 pub(crate) mod internal;
 mod iterators;
 mod operations;
+#[cfg(feature = "serde")]
+mod serde;
 mod traits;
 
 pub use chunked_vec::*;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,80 @@
+//! [`Serialize`] and [`Deserialize`] implementations for [`ChunkedVec`].
+//!
+//! `ChunkedVec<T, N>` is serialized as a plain sequence of its elements,
+//! exactly like `Vec<T>`, so the two are interchangeable on the wire. The
+//! chunk size `N` is a memory-layout detail and is not part of the format.
+
+use core::fmt;
+use core::marker::PhantomData;
+
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
+use serde::ser::{Serialize, SerializeSeq, Serializer};
+
+use crate::{ChunkedVec, ChunkedVecSized};
+
+/// Serializes the `ChunkedVec` as a sequence of its elements.
+///
+/// # Examples
+/// ```
+/// use chunked_vec::chunked_vec;
+///
+/// let vec = chunked_vec![1, 2, 3];
+/// assert_eq!(serde_json::to_string(&vec).unwrap(), "[1,2,3]");
+/// ```
+impl<T, const N: usize> Serialize for ChunkedVec<T, N>
+where
+    T: Serialize,
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for elem in self.iter() {
+            seq.serialize_element(elem)?;
+        }
+        seq.end()
+    }
+}
+
+/// Deserializes a sequence of elements into a `ChunkedVec`.
+///
+/// # Examples
+/// ```
+/// use chunked_vec::ChunkedVec;
+///
+/// let vec: ChunkedVec<i32> = serde_json::from_str("[1,2,3]").unwrap();
+/// assert_eq!(vec, [1, 2, 3]);
+/// ```
+impl<'de, T, const N: usize> Deserialize<'de> for ChunkedVec<T, N>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ChunkedVecVisitor<T, const N: usize>(PhantomData<T>);
+
+        impl<'de, T, const N: usize> Visitor<'de> for ChunkedVecVisitor<T, N>
+        where
+            T: Deserialize<'de>,
+        {
+            type Value = ChunkedVec<T, N>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a sequence")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                // size_hint comes from the input data (e.g. bincode's length
+                // prefix), so corrupt or malicious input can claim an absurdly
+                // large length. Cap what we preallocate from it; a genuinely
+                // longer sequence still grows normally via push.
+                const PREALLOC_CAP: usize = 4096;
+                let cap = seq.size_hint().unwrap_or(0).min(PREALLOC_CAP);
+                let mut vec = ChunkedVecSized::<T, N>::with_capacity(cap);
+                while let Some(elem) = seq.next_element()? {
+                    vec.push(elem);
+                }
+                Ok(vec)
+            }
+        }
+
+        deserializer.deserialize_seq(ChunkedVecVisitor(PhantomData))
+    }
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,115 @@
+#![cfg(feature = "serde")]
+
+use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+use chunked_vec::{chunked_vec, ChunkedVec, ChunkedVecSized};
+use serde::de::{Deserialize, Deserializer};
+
+fn round_trip<const N: usize>(vec: &ChunkedVec<i32, N>) -> ChunkedVec<i32, N> {
+    let json = serde_json::to_string(vec).unwrap();
+    serde_json::from_str(&json).unwrap()
+}
+
+#[test]
+fn round_trip_empty() {
+    let vec = ChunkedVec::<i32>::new();
+    assert_eq!(serde_json::to_string(&vec).unwrap(), "[]");
+    let back = round_trip(&vec);
+    assert!(back.is_empty());
+}
+
+#[test]
+fn round_trip_default_n() {
+    let vec: ChunkedVec<i32> = (0..10).collect();
+    let back = round_trip(&vec);
+    assert_eq!(back.len(), vec.len());
+    assert!(back.iter().eq(vec.iter()));
+}
+
+#[test]
+fn round_trip_exact_chunk_boundary() {
+    for len in [4, 8] {
+        let mut vec: ChunkedVec<i32, 4> = ChunkedVecSized::new();
+        for i in 0..len {
+            vec.push(i);
+        }
+        let back = round_trip(&vec);
+        assert_eq!(back.len(), len as usize);
+        assert!(back.iter().eq(vec.iter()));
+    }
+}
+
+#[test]
+fn round_trip_multiple_chunks_non_default_n() {
+    let mut vec: ChunkedVec<i32, 4> = ChunkedVecSized::new();
+    for i in 0..10 {
+        vec.push(i);
+    }
+    let back = round_trip(&vec);
+    assert!(back.iter().eq(vec.iter()));
+}
+
+#[test]
+fn round_trip_strings() {
+    let mut vec: ChunkedVec<String, 2> = ChunkedVecSized::new();
+    for s in ["alpha", "beta", "gamma", "delta", "epsilon"] {
+        vec.push(s.to_string());
+    }
+    let json = serde_json::to_string(&vec).unwrap();
+    let back: ChunkedVec<String, 2> = serde_json::from_str(&json).unwrap();
+    assert!(back.iter().eq(vec.iter()));
+}
+
+#[test]
+fn interop_with_vec() {
+    let chunked = chunked_vec![1, 2, 3, 4, 5];
+    let std_vec = vec![1, 2, 3, 4, 5];
+
+    let chunked_json = serde_json::to_string(&chunked).unwrap();
+    let std_json = serde_json::to_string(&std_vec).unwrap();
+    assert_eq!(chunked_json, std_json);
+
+    let from_std: ChunkedVec<i32, 3> = serde_json::from_str(&std_json).unwrap();
+    assert!(from_std.iter().eq(std_vec.iter()));
+
+    let from_chunked: Vec<i32> = serde_json::from_str(&chunked_json).unwrap();
+    assert_eq!(from_chunked, std_vec);
+}
+
+#[test]
+fn chunk_size_is_not_part_of_format() {
+    let mut vec: ChunkedVec<i32, 4> = ChunkedVecSized::new();
+    for i in 0..10 {
+        vec.push(i);
+    }
+    let json = serde_json::to_string(&vec).unwrap();
+    let back: ChunkedVec<i32, 16> = serde_json::from_str(&json).unwrap();
+    assert!(back.iter().eq(vec.iter()));
+}
+
+static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug)]
+struct DropCounter(#[allow(dead_code)] i32);
+
+impl Drop for DropCounter {
+    fn drop(&mut self) {
+        DROP_COUNT.fetch_add(1, SeqCst);
+    }
+}
+
+impl<'de> Deserialize<'de> for DropCounter {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        i32::deserialize(deserializer).map(DropCounter)
+    }
+}
+
+#[test]
+fn drop_safety_on_mid_sequence_error() {
+    // Keep this the only test that touches DROP_COUNT: tests run in parallel.
+    DROP_COUNT.store(0, SeqCst);
+    let result: Result<ChunkedVec<DropCounter, 2>, _> = serde_json::from_str("[1, 2, 3, \"boom\"]");
+    assert!(result.is_err());
+    // The 3 elements pushed before the error must be dropped exactly once each.
+    assert_eq!(DROP_COUNT.load(SeqCst), 3);
+}


### PR DESCRIPTION
Implement Serialize and Deserialize for ChunkedVec<T, N> (any chunk size N), gated behind a new opt-in `serde` cargo feature. Values are serialized as a plain sequence, making the wire format fully interoperable with Vec<T>.

- Serialize iterates elements with an explicit length hint for length-prefixed formats like bincode
- Deserialize uses a SeqAccess visitor with with_capacity + push, so the len/initialized invariant holds at every step and a mid-sequence error drops partial contents correctly (no unsafe code)
- Preallocation from size_hint is capped to guard against corrupt or malicious length prefixes
- Add tests/serde.rs: round trips (empty, chunk boundaries, non-default N, String), Vec<T> interop, cross-N round trip, drop safety on error
- Configure docs.rs to build with all features